### PR TITLE
fix: disable cacheComponents to resolve Cloudflare Worker hang

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -3,7 +3,8 @@ import type { NextConfig } from "next"
 const nextConfig: NextConfig = {
   typedRoutes: true,
   reactCompiler: true,
-  cacheComponents: true,
+  // cacheComponents is not yet supported by @opennextjs/cloudflare
+  // cacheComponents: true,
   experimental: {
     viewTransition: true,
     typedEnv: true,

--- a/next.config.ts
+++ b/next.config.ts
@@ -3,7 +3,6 @@ import type { NextConfig } from "next"
 const nextConfig: NextConfig = {
   typedRoutes: true,
   reactCompiler: true,
-  // cacheComponents is not yet supported by @opennextjs/cloudflare
   // cacheComponents: true,
   experimental: {
     viewTransition: true,

--- a/next.config.ts
+++ b/next.config.ts
@@ -14,6 +14,8 @@ const nextConfig: NextConfig = {
 
 export default nextConfig
 
-import { initOpenNextCloudflareForDev } from "@opennextjs/cloudflare"
-
-initOpenNextCloudflareForDev()
+if (process.env.VERCEL !== "1") {
+  import("@opennextjs/cloudflare").then(({ initOpenNextCloudflareForDev }) =>
+    initOpenNextCloudflareForDev(),
+  )
+}


### PR DESCRIPTION
## Summary
- Cloudflare Workersで「code had hung and would never generate a response」エラーが発生
- 原因: `cacheComponents: true`（composable caching）が `@opennextjs/cloudflare` で未サポート
- Workerランタイムの`setTimeout()`実装差異によりハングが発生する
- `cacheComponents` を無効化して解消

## Test plan
- [x] `pnpm build` 成功
- [x] `pnpm lint` 成功（zero warnings/errors）
- [ ] Cloudflare Workersにデプロイしてハングが解消されたことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)