### PR TITLE
feat: add works and writing sections

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -3,6 +3,24 @@ import type { NextConfig } from "next"
 const nextConfig: NextConfig = {
   typedRoutes: true,
   reactCompiler: true,
+  async headers() {
+    return [
+      {
+        source: "/llms.txt",
+        headers: [
+          { key: "Content-Type", value: "text/plain; charset=utf-8" },
+          { key: "Content-Disposition", value: "inline" },
+        ],
+      },
+      {
+        source: "/llms-full.txt",
+        headers: [
+          { key: "Content-Type", value: "text/plain; charset=utf-8" },
+          { key: "Content-Disposition", value: "inline" },
+        ],
+      },
+    ]
+  },
   experimental: {
     viewTransition: true,
     typedEnv: true,

--- a/src/app/apps/[appId]/page.tsx
+++ b/src/app/apps/[appId]/page.tsx
@@ -9,6 +9,7 @@ import { Tag } from "@/components/tui/primitives"
 import { apps } from "@/data/apps"
 
 export const appComponents: Record<string, React.ComponentType> = {
+  fontlens: dynamic(() => import("@/apps/fontlens")),
   timezone: dynamic(() => import("@/apps/timezone")),
   "lorem-text": dynamic(() => import("@/apps/lorem-text")),
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -12,6 +12,16 @@ const routes = [
     description: "6 principles",
   },
   { command: "ls apps", path: "/apps", description: "utility apps" },
+  {
+    command: "ls works",
+    path: "/works",
+    description: "published products",
+  },
+  {
+    command: "ls writing",
+    path: "/writing",
+    description: "technical articles",
+  },
 ] as const
 
 // Render per-request so the header timestamp reflects "now" on each visit

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -29,6 +29,18 @@ export default function sitemap(): MetadataRoute.Sitemap {
       changeFrequency: "weekly",
       priority: 0.8,
     },
+    {
+      url: `${base}/works`,
+      lastModified: new Date(),
+      changeFrequency: "weekly",
+      priority: 0.7,
+    },
+    {
+      url: `${base}/writing`,
+      lastModified: new Date(),
+      changeFrequency: "daily",
+      priority: 0.7,
+    },
   ]
 
   const appRoutes: MetadataRoute.Sitemap = apps.map((app) => ({

--- a/src/app/works/page.tsx
+++ b/src/app/works/page.tsx
@@ -1,0 +1,83 @@
+import type { Metadata } from "next"
+import { PageLayout } from "@/components/page-layout"
+import { Block, BlockStream } from "@/components/tui/block"
+import { Tag } from "@/components/tui/primitives"
+import { works } from "@/data/works"
+
+export const metadata: Metadata = {
+  title: "works",
+  description:
+    "Published products and tools by kage1020 across VS Code Marketplace and PyPI.",
+}
+
+const statusTone: Record<string, "success" | "warn" | "default"> = {
+  published: "success",
+  active: "warn",
+}
+
+const platformLabel: Record<string, string> = {
+  "vscode-marketplace": "VS Marketplace",
+  pypi: "PyPI",
+}
+
+export default function WorksPage() {
+  return (
+    <PageLayout>
+      <BlockStream>
+        <Block
+          command="ls -la works/"
+          duration={`${works.length} entries`}
+          timestamp="published products"
+        >
+          <p className="max-w-2xl text-text-secondary">
+            External products and packages published outside this website.
+          </p>
+        </Block>
+
+        <Block
+          command="cat works/index.json"
+          duration={`${works.length} entries`}
+        >
+          <ul className="space-y-4">
+            {works.map((work) => (
+              <li key={work.id}>
+                <a
+                  href={work.url}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="group block"
+                >
+                  <div className="flex flex-wrap items-baseline gap-x-3 gap-y-1">
+                    <span className="text-text-muted group-hover:text-accent-bright">
+                      →
+                    </span>
+                    <span className="text-text-primary group-hover:text-accent-bright">
+                      {work.title}
+                    </span>
+                    <Tag tone={statusTone[work.status] ?? "default"}>
+                      {work.status}
+                    </Tag>
+                    <Tag tone="accent">
+                      {platformLabel[work.platform] ?? work.platform}
+                    </Tag>
+                    <span className="text-text-muted">{work.kind}</span>
+                  </div>
+                  <p className="ml-6 mt-1 text-text-secondary">
+                    {work.description}
+                  </p>
+                  <div className="ml-6 mt-2 flex flex-wrap gap-2">
+                    {work.technologies.map((tech) => (
+                      <span key={tech} className="font-mono text-text-muted">
+                        #{tech}
+                      </span>
+                    ))}
+                  </div>
+                </a>
+              </li>
+            ))}
+          </ul>
+        </Block>
+      </BlockStream>
+    </PageLayout>
+  )
+}

--- a/src/app/writing/page.tsx
+++ b/src/app/writing/page.tsx
@@ -1,0 +1,96 @@
+import type { Metadata } from "next"
+import { PageLayout } from "@/components/page-layout"
+import { Block, BlockStream } from "@/components/tui/block"
+import { Tag } from "@/components/tui/primitives"
+import { getWritingArticles } from "@/data/writing"
+
+export const metadata: Metadata = {
+  title: "writing",
+  description: "Technical writing from Qiita and Zenn.",
+}
+
+export const revalidate = 60 * 60
+
+function formatDate(isoDate: string) {
+  return new Date(isoDate).toLocaleDateString("ja-JP", {
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+  })
+}
+
+export default async function WritingPage() {
+  const articles = await getWritingArticles()
+
+  return (
+    <PageLayout>
+      <BlockStream>
+        <Block
+          command="fetch writing --source qiita,zenn"
+          duration={`${articles.length} entries`}
+          timestamp="API sync"
+        >
+          <p className="max-w-2xl text-text-secondary">
+            Technical articles fetched from Qiita and Zenn APIs.
+          </p>
+        </Block>
+
+        <Block
+          command="cat writing/index.json"
+          duration={`${articles.length} entries`}
+        >
+          {articles.length === 0 ? (
+            <p className="text-text-secondary">
+              Failed to fetch articles right now. Please try again later.
+            </p>
+          ) : (
+            <ul className="space-y-4">
+              {articles.map((article) => (
+                <li key={article.id}>
+                  <a
+                    href={article.url}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="group block"
+                  >
+                    <div className="grid grid-cols-[max-content_1fr] gap-x-3 gap-y-1">
+                      <span className="text-text-muted group-hover:text-accent-bright">
+                        →
+                      </span>
+                      <div className="min-w-0">
+                        <span className="block wrap-break-word text-text-primary group-hover:text-accent-bright">
+                          {article.title}
+                        </span>
+                        <div className="mt-1 flex flex-wrap items-baseline gap-x-3 gap-y-1">
+                          <Tag tone="accent">{article.platform}</Tag>
+                          <span className="text-text-muted">
+                            {formatDate(article.publishedAt)}
+                          </span>
+                          <span className="text-text-muted">
+                            ❤ {article.likes}
+                          </span>
+                        </div>
+                      </div>
+                    </div>
+                    {article.tags.length > 0 && (
+                      <div className="ml-6 mt-2 flex flex-wrap gap-2">
+                        {article.tags.map((tag) => (
+                          <span
+                            key={`${article.id}-${tag}`}
+                            className="font-mono text-text-muted"
+                          >
+                            #{tag}
+                          </span>
+                        ))}
+                      </div>
+                    )}
+                  </a>
+                </li>
+              ))}
+            </ul>
+          )}
+        </Block>
+      </BlockStream>
+    </PageLayout>
+  )
+}

--- a/src/app/writing/page.tsx
+++ b/src/app/writing/page.tsx
@@ -1,7 +1,7 @@
 import type { Metadata } from "next"
 import { PageLayout } from "@/components/page-layout"
 import { Block, BlockStream } from "@/components/tui/block"
-import { Tag } from "@/components/tui/primitives"
+import { KV, Tag } from "@/components/tui/primitives"
 import { getWritingArticles } from "@/data/writing"
 
 export const metadata: Metadata = {
@@ -35,59 +35,55 @@ export default async function WritingPage() {
           </p>
         </Block>
 
-        <Block
-          command="cat writing/index.json"
-          duration={`${articles.length} entries`}
-        >
+        <Block command="cat writing/index.kv" duration={`${articles.length} entries`}>
           {articles.length === 0 ? (
             <p className="text-text-secondary">
               Failed to fetch articles right now. Please try again later.
             </p>
           ) : (
-            <ul className="space-y-4">
+            <div className="space-y-6">
               {articles.map((article) => (
-                <li key={article.id}>
-                  <a
-                    href={article.url}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    className="group block"
-                  >
-                    <div className="grid grid-cols-[max-content_1fr] gap-x-3 gap-y-1">
-                      <span className="text-text-muted group-hover:text-accent-bright">
-                        →
-                      </span>
-                      <div className="min-w-0">
-                        <span className="block wrap-break-word text-text-primary group-hover:text-accent-bright">
+                <KV
+                  key={article.id}
+                  rows={[
+                    {
+                      key: "title",
+                      value: (
+                        <a
+                          href={article.url}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          className="wrap-break-word text-accent-bright hover:text-accent"
+                        >
                           {article.title}
-                        </span>
-                        <div className="mt-1 flex flex-wrap items-baseline gap-x-3 gap-y-1">
-                          <Tag tone="accent">{article.platform}</Tag>
-                          <span className="text-text-muted">
-                            {formatDate(article.publishedAt)}
-                          </span>
-                          <span className="text-text-muted">
-                            ❤ {article.likes}
-                          </span>
-                        </div>
-                      </div>
-                    </div>
-                    {article.tags.length > 0 && (
-                      <div className="ml-6 mt-2 flex flex-wrap gap-2">
-                        {article.tags.map((tag) => (
-                          <span
-                            key={`${article.id}-${tag}`}
-                            className="font-mono text-text-muted"
-                          >
-                            #{tag}
-                          </span>
-                        ))}
-                      </div>
-                    )}
-                  </a>
-                </li>
+                        </a>
+                      ),
+                    },
+                    {
+                      key: "url",
+                      value: (
+                        <a
+                          href={article.url}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          className="wrap-break-word text-text-secondary hover:text-accent-bright"
+                        >
+                          {article.url}
+                        </a>
+                      ),
+                    },
+                    { key: "platform", value: <Tag tone="accent">{article.platform}</Tag> },
+                    { key: "published", value: formatDate(article.publishedAt) },
+                    { key: "likes", value: article.likes },
+                    {
+                      key: "tags",
+                      value:
+                        article.tags.length > 0 ? article.tags.join(", ") : "(none)",
+                    },
+                  ]}
+                />
               ))}
-            </ul>
+            </div>
           )}
         </Block>
       </BlockStream>

--- a/src/app/writing/page.tsx
+++ b/src/app/writing/page.tsx
@@ -9,7 +9,7 @@ export const metadata: Metadata = {
   description: "Technical writing from Qiita and Zenn.",
 }
 
-export const revalidate = 60 * 60
+export const revalidate = 3600
 
 function formatDate(isoDate: string) {
   return new Date(isoDate).toLocaleDateString("ja-JP", {

--- a/src/apps/fontlens/index.tsx
+++ b/src/apps/fontlens/index.tsx
@@ -1,0 +1,29 @@
+"use client"
+
+const FONTLENS_URL = "https://fontlens.kage1020.com"
+
+export default function FontLensApp() {
+  return (
+    <div className="space-y-5">
+      <p className="text-text-secondary">
+        Font Lens is a web font comparator focused on real usage checks, not
+        isolated specimen views.
+      </p>
+      <ul className="space-y-1.5 font-mono text-sm text-text-secondary">
+        <li>• Compare Google Fonts, custom CDN URLs, and system fonts</li>
+        <li>
+          • Validate typography in body, headings, UI labels, and code blocks
+        </li>
+        <li>• Check multilingual rendering under the same visual conditions</li>
+      </ul>
+      <a
+        href={FONTLENS_URL}
+        target="_blank"
+        rel="noopener noreferrer"
+        className="inline-flex items-center rounded border border-surface-2 bg-surface-1 px-3 py-2 font-mono text-sm text-text-secondary transition-colors hover:border-accent hover:text-accent-bright"
+      >
+        open {FONTLENS_URL} ↗
+      </a>
+    </div>
+  )
+}

--- a/src/apps/lorem-text/index.tsx
+++ b/src/apps/lorem-text/index.tsx
@@ -337,6 +337,15 @@ export default function LoremTextApp() {
 
   return (
     <div className="space-y-6">
+      <a
+        href={UPSTREAM}
+        target="_blank"
+        rel="noopener noreferrer"
+        className="inline-flex items-center rounded border border-surface-2 bg-surface-1 px-3 py-1.5 font-mono text-xs text-text-muted transition-colors hover:border-accent hover:text-accent-bright"
+      >
+        open {UPSTREAM} ↗
+      </a>
+
       {/* Category + endpoint picker */}
       <div className="space-y-4 sm:space-y-3">
         {categories.map((category) => (

--- a/src/components/command-input.tsx
+++ b/src/components/command-input.tsx
@@ -10,12 +10,22 @@ const commands: Record<string, string> = {
   philosophy: "/philosophy",
   "ls apps": "/apps",
   apps: "/apps",
+  "ls works": "/works",
+  works: "/works",
+  "ls writing": "/writing",
+  writing: "/writing",
   home: "/",
   cd: "/",
   "cd ~": "/",
 }
 
-const suggestions = ["whoami", "cat philosophy", "ls apps"]
+const suggestions = [
+  "whoami",
+  "cat philosophy",
+  "ls apps",
+  "ls works",
+  "ls writing",
+]
 
 export function CommandInput({
   autoFocus = false,

--- a/src/data/apps.ts
+++ b/src/data/apps.ts
@@ -9,6 +9,15 @@ type App = {
 
 export const apps: App[] = [
   {
+    id: "fontlens",
+    title: "Font Lens",
+    description:
+      "Compare Google Fonts, custom CDN fonts, and system fonts side-by-side across body, headings, UI, and code contexts.",
+    status: "active",
+    technologies: ["React", "TypeScript", "Cloudflare", "Web Fonts"],
+    category: "Developer Tool",
+  },
+  {
     id: "timezone",
     title: "World Timezone",
     description:
@@ -23,7 +32,7 @@ export const apps: App[] = [
     description:
       "UI for random.kage1020.com — generate identifiers (CUID, UUID, ULID), random strings, Japanese text, and Lorem Ipsum.",
     status: "active",
-    technologies: ["React", "TypeScript", "random.kage1020.com"],
+    technologies: ["React", "TypeScript", "Cloudflare", "Hono"],
     category: "Developer Tool",
   },
 ]

--- a/src/data/works.ts
+++ b/src/data/works.ts
@@ -1,0 +1,45 @@
+export type Work = {
+  id: string
+  title: string
+  description: string
+  platform: "vscode-marketplace" | "pypi"
+  kind: "extension" | "package"
+  url: string
+  status: "published" | "active"
+  technologies: string[]
+}
+
+export const works: Work[] = [
+  {
+    id: "icon-collection",
+    title: "Icon Collection",
+    description:
+      "VS Code extension to search icon libraries and copy SVG/Draw.io data quickly.",
+    platform: "vscode-marketplace",
+    kind: "extension",
+    url: "https://marketplace.visualstudio.com/items?itemName=kage1020.icon-collection",
+    status: "published",
+    technologies: ["VS Code Extension", "TypeScript"],
+  },
+  {
+    id: "vut",
+    title: "vut",
+    description: "Python package published on PyPI.",
+    platform: "pypi",
+    kind: "package",
+    url: "https://pypi.org/project/vut/0.1.7/",
+    status: "published",
+    technologies: ["Python", "PyPI"],
+  },
+  {
+    id: "react-component-color",
+    title: "React Component Color",
+    description:
+      "VS Code extension that color-codes React Server/Client components.",
+    platform: "vscode-marketplace",
+    kind: "extension",
+    url: "https://marketplace.visualstudio.com/items?itemName=kage1020.react-component-color",
+    status: "published",
+    technologies: ["VS Code Extension", "TypeScript", "React"],
+  },
+]

--- a/src/data/works.ts
+++ b/src/data/works.ts
@@ -14,7 +14,7 @@ export const works: Work[] = [
     id: "icon-collection",
     title: "Icon Collection",
     description:
-      "VS Code extension to search icon libraries and copy SVG/Draw.io data quickly.",
+      "VS Code extension for exploring icon libraries inside the editor. Search by keyword, then copy SVG snippets or Draw.io-ready diagram data directly to the clipboard for fast prototyping and documentation.",
     platform: "vscode-marketplace",
     kind: "extension",
     url: "https://marketplace.visualstudio.com/items?itemName=kage1020.icon-collection",
@@ -24,10 +24,11 @@ export const works: Work[] = [
   {
     id: "vut",
     title: "vut",
-    description: "Python package published on PyPI.",
+    description:
+      "Video Understanding Toolkit (Python). A modular library for video understanding tasks such as video classification and action recognition, designed to be extensible for additional models and datasets.",
     platform: "pypi",
     kind: "package",
-    url: "https://pypi.org/project/vut/0.1.7/",
+    url: "https://pypi.org/project/vut/",
     status: "published",
     technologies: ["Python", "PyPI"],
   },
@@ -35,7 +36,7 @@ export const works: Work[] = [
     id: "react-component-color",
     title: "React Component Color",
     description:
-      "VS Code extension that color-codes React Server/Client components.",
+      "VS Code extension that visually distinguishes React Server and Client Components in JSX/TSX. It detects `use client` boundaries and client-only usage patterns so component roles are easier to understand in large codebases.",
     platform: "vscode-marketplace",
     kind: "extension",
     url: "https://marketplace.visualstudio.com/items?itemName=kage1020.react-component-color",

--- a/src/data/writing.ts
+++ b/src/data/writing.ts
@@ -1,0 +1,107 @@
+export type WritingPlatform = "qiita" | "zenn"
+
+export type WritingArticle = {
+  id: string
+  title: string
+  url: string
+  platform: WritingPlatform
+  publishedAt: string
+  likes: number
+  tags: string[]
+}
+
+const QIITA_USER = "kage1020"
+const ZENN_USER = "kage1020"
+const REVALIDATE_SECONDS = 60 * 60
+const ARTICLE_LIMIT = 20
+
+type QiitaItem = {
+  id: string
+  title: string
+  url: string
+  created_at: string
+  likes_count: number
+  tags: { name: string }[]
+}
+
+type ZennArticle = {
+  id: number
+  title: string
+  path: string
+  published_at?: string
+  liked_count: number
+}
+
+type ZennResponse = {
+  articles: ZennArticle[]
+}
+
+function normalizeZennUrl(path: string) {
+  if (path.startsWith("http://") || path.startsWith("https://")) return path
+  if (path.startsWith("/")) return `https://zenn.dev${path}`
+  return `https://zenn.dev/${ZENN_USER}/articles/${path}`
+}
+
+async function fetchQiitaArticles(): Promise<WritingArticle[]> {
+  const res = await fetch(
+    `https://qiita.com/api/v2/users/${QIITA_USER}/items?page=1&per_page=${ARTICLE_LIMIT}`,
+    {
+      next: { revalidate: REVALIDATE_SECONDS },
+      headers: { Accept: "application/json" },
+    },
+  )
+
+  if (!res.ok) return []
+
+  const items = (await res.json()) as QiitaItem[]
+  return items.map((item) => ({
+    id: `qiita-${item.id}`,
+    title: item.title,
+    url: item.url,
+    platform: "qiita",
+    publishedAt: item.created_at,
+    likes: item.likes_count ?? 0,
+    tags: item.tags.map((tag) => tag.name),
+  }))
+}
+
+async function fetchZennArticles(): Promise<WritingArticle[]> {
+  const res = await fetch(
+    `https://zenn.dev/api/articles?username=${ZENN_USER}&order=latest`,
+    {
+      next: { revalidate: REVALIDATE_SECONDS },
+      headers: { Accept: "application/json" },
+    },
+  )
+
+  if (!res.ok) return []
+
+  const body = (await res.json()) as ZennResponse
+  return body.articles.slice(0, ARTICLE_LIMIT).map((article) => ({
+    id: `zenn-${article.id}`,
+    title: article.title,
+    url: normalizeZennUrl(article.path),
+    platform: "zenn",
+    publishedAt: article.published_at ?? "",
+    likes: article.liked_count ?? 0,
+    tags: [],
+  }))
+}
+
+export async function getWritingArticles() {
+  const [qiitaResult, zennResult] = await Promise.allSettled([
+    fetchQiitaArticles(),
+    fetchZennArticles(),
+  ])
+
+  const qiitaArticles =
+    qiitaResult.status === "fulfilled" ? qiitaResult.value : []
+  const zennArticles = zennResult.status === "fulfilled" ? zennResult.value : []
+
+  return [...qiitaArticles, ...zennArticles]
+    .filter((article) => article.publishedAt)
+    .sort(
+      (a, b) =>
+        new Date(b.publishedAt).getTime() - new Date(a.publishedAt).getTime(),
+    )
+}


### PR DESCRIPTION
## Summary
- Add a new `/works` section with structured data for externally published products (VS Marketplace and PyPI).
- Add a new `/writing` section that fetches and merges technical articles from Qiita and Zenn APIs with revalidation.
- Update navigation commands and sitemap to include the new sections, and improve writing list wrapping for long (including Japanese) titles.

## Test plan
- [x] `pnpm lint`
- [x] `pnpm exec tsc --noEmit`
- [ ] Open `/works` and verify external links render correctly.
- [ ] Open `/writing` and verify articles are fetched and long Japanese titles wrap naturally.
- [ ] Verify command input navigation for `ls works` and `ls writing`.

Made with [Cursor](https://cursor.com)