### PR TITLE
fix: llms.txt/llms-full.txt の UTF-8 charset を明示

### DIFF
--- a/public/_headers
+++ b/public/_headers
@@ -1,3 +1,9 @@
 # https://developers.cloudflare.com/workers/static-assets/headers
 /_next/static/*
   Cache-Control: public,max-age=31536000,immutable
+
+/llms.txt
+  Content-Type: text/plain; charset=utf-8
+
+/llms-full.txt
+  Content-Type: text/plain; charset=utf-8


### PR DESCRIPTION
## Summary
- `public/_headers` に `/llms.txt` と `/llms-full.txt` の `Content-Type: text/plain; charset=utf-8` を追加
- Android/Windows/macOS の各ブラウザで日本語が文字化けしていた問題を解消

## 背景
ファイル自体は UTF-8 で正しく保存されているが、Cloudflare がデフォルトで返す `Content-Type: text/plain` には charset が含まれず、ブラウザが Shift_JIS 等で誤って解釈していた（GitHub 上では独自に UTF-8 として表示されるため化けない）。

## Test plan
- [ ] デプロイ後、`curl -I https://kage1020.com/llms.txt` で `Content-Type: text/plain; charset=utf-8` が返ることを確認
- [ ] Android Chrome で https://kage1020.com/llms.txt にアクセスし日本語が正常表示されることを確認
- [ ] 同様に https://kage1020.com/llms-full.txt も確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)